### PR TITLE
style: ensure full width layout for product cards and filters

### DIFF
--- a/frontend/src/components/category/ProductsFilter.vue
+++ b/frontend/src/components/category/ProductsFilter.vue
@@ -25,12 +25,12 @@
             /> -->
             <h2 class="text-[8px] filter-title">Категорий</h2>
           </label>
-          <div class="overflow-x-auto min-h-11 py-5 px-2" ref="scrollContainer">
-            <button class="absolute top-[50px] left-1 z-10 cursor-pointer" @click="scroll(-150)">
+          <div class="overflow-x-auto min-h-11 py-5 px-2 flex" ref="scrollContainer">
+            <button class="absolute top-[65px] left-1 z-10 cursor-pointer i" @click="scroll(-150)">
               ⬅
             </button>
             <ui-button
-              class="mr-2"
+              class="mr-2 shrink-0"
               :class="{ active: $route.params.id === 'all' }"
               :variant="$route.params.id === 'all' ? 'dark' : 'outline'"
               :to="{ name: 'category', params: { id: 'all' } }"
@@ -38,7 +38,7 @@
               >Все</ui-button
             >
             <ui-button
-              class="mr-2"
+              class="mr-2 shrink-0"
               :class="{ active: $route.params.id === item.id }"
               :variant="$route.params.id === item.id ? 'dark' : 'outline'"
               :to="{ name: 'category', params: { id: item.id } }"
@@ -50,7 +50,7 @@
 
             <!-- arrow -->
             <button
-              class="absolute right-1 z-10 top-[50px] cursor-pointer rotate-180"
+              class="absolute right-1 z-10 top-[65px] cursor-pointer rotate-180"
               @click="scroll(150)"
             >
               ⬅

--- a/frontend/src/components/category/ProductsList.vue
+++ b/frontend/src/components/category/ProductsList.vue
@@ -17,8 +17,8 @@
         class="justify-self-center"
       />
     </template>
-    <div ref="sentinel"></div>
   </div>
+  <div ref="sentinel" class="mt-20"></div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/shared/ProductCardShared.vue
+++ b/frontend/src/components/shared/ProductCardShared.vue
@@ -1,10 +1,10 @@
 <template>
   <article
     v-if="props.product"
-    class="product-card flex gap-3 relative rounded-2xl shadow transition shadow-neutral-800/70 hover overflow-hidden max-w-[25rem]"
+    class="product-card flex gap-3 relative rounded-2xl shadow transition shadow-neutral-800/70 hover overflow-hidden max-w-[25rem] !w-full"
     :class="{
       'flex-row max-h-[7rem] w-full ': variant === 'cart',
-      'h-[26rem] max-w-[20rem]  flex-col': variant === 'default' || variant === 'favorite',
+      'h-[26rem] !max-w-[22rem]  flex-col ': variant === 'default' || variant === 'favorite',
     }"
   >
     <div
@@ -62,7 +62,7 @@
 
         <div class="flex gap-3 justify-between">
           <div
-            class="product-card__footer flex justify-between items-center pl-3"
+            class="product-card__footer flex justify-between items-center pl-3 grow"
             v-if="variant === 'cart' || variant === 'default'"
           >
             <div class="product-card__controlls flex justify-center items-center gap-3">

--- a/frontend/src/skeltons/SkeltonProductCard.vue
+++ b/frontend/src/skeltons/SkeltonProductCard.vue
@@ -1,9 +1,9 @@
 <template>
   <article
-    class="product-card flex gap-3 relative rounded-2xl shadow animate-pulse bg-neutral-200 overflow-hidden"
+    class="product-card flex gap-3 relative rounded-2xl shadow animate-pulse bg-neutral-200 overflow-hidden !w-full"
     :class="{
       'flex-row max-h-[7rem] w-full': variant === 'cart',
-      'h-[26rem] max-w-[20rem] flex-col': variant === 'default' || variant === 'favorite',
+      'h-[26rem] !max-w-[22rem] flex-col': variant === 'default' || variant === 'favorite',
     }"
   >
     <div


### PR DESCRIPTION
- style(filter-container): add `shrink-0` to prevent category buttons compression
- style(product-card): add `!w-full` to make cards occupy full grid cell width
- style(skeleton-card): apply same `!w-full` fix for loading states

:)